### PR TITLE
add Python wrappers for audit_subscribe and callback_subscribe

### DIFF
--- a/sdk/python/faramesh/__init__.py
+++ b/sdk/python/faramesh/__init__.py
@@ -82,6 +82,11 @@ from .gate import (
     ReplayResult,
 )
 
+# Import socket-stream submodules:
+#   audit     -> wraps `audit_subscribe`     (governance decisions)
+#   callbacks -> wraps `callback_subscribe`  (lifecycle events: defer_resolved, etc.)
+from . import audit, callbacks
+
 # Import version
 from .client import __version__
 
@@ -181,6 +186,10 @@ __all__ = [
     "GovernorAuthError",
     "GovernorConnectionError",
     
+    # Socket-stream submodules
+    "audit",
+    "callbacks",
+
     # Version
     "__version__",
 ]

--- a/sdk/python/faramesh/_subscription.py
+++ b/sdk/python/faramesh/_subscription.py
@@ -1,0 +1,194 @@
+"""Shared subscription machinery for Faramesh's SDK socket streams.
+
+Internal module — consumers should use :mod:`faramesh.audit` (decision
+stream) or :mod:`faramesh.callbacks` (lifecycle stream) rather than
+importing from here directly.
+
+Both public modules wrap the same Unix-socket protocol: send a
+newline-delimited JSON request of a known ``type`` (``audit_subscribe``
+or ``callback_subscribe``), wait for a ``{"subscribed": true, ...}``
+confirmation, then read newline-delimited JSON events on a background
+thread until the consumer closes the subscription.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket as _socket
+import threading
+from collections.abc import Callable
+from typing import Any
+
+logger = logging.getLogger("faramesh.subscription")
+
+AUDIT_SUBSCRIBE = "audit_subscribe"
+CALLBACK_SUBSCRIBE = "callback_subscribe"
+
+
+def default_socket_path() -> str:
+    """Resolve the daemon socket path. Matches autopatch.py's convention."""
+    return os.environ.get("FARAMESH_SOCKET", "/tmp/faramesh.sock")
+
+
+class Subscription:
+    """Handle for an active subscription to one of the daemon's streams.
+
+    Constructed via :func:`faramesh.audit.subscribe` (decisions) or
+    :func:`faramesh.callbacks.subscribe` (lifecycle). Use as a context
+    manager (preferred) or call ``close()`` explicitly.
+    """
+
+    def __init__(
+        self,
+        callback: Callable[[dict[str, Any]], None],
+        *,
+        request_type: str,
+        agent_id: str | None = None,
+        socket_path: str | None = None,
+        connect_timeout: float = 5.0,
+    ):
+        self._callback = callback
+        self._request_type = request_type
+        self._agent_id = agent_id
+        self._socket_path = socket_path or default_socket_path()
+        self._connect_timeout = connect_timeout
+
+        self._sock: _socket.socket | None = None
+        self._thread: threading.Thread | None = None
+        self._stop = threading.Event()
+        self._ready = threading.Event()
+        self._start_error: Exception | None = None
+
+    def __enter__(self) -> "Subscription":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    def start(self) -> None:
+        """Open the socket, send the subscribe request, and start the read loop.
+
+        Blocks until the daemon's ``{"subscribed": true}`` confirmation arrives
+        (or the connect/handshake fails), so that errors surface immediately
+        rather than from the background thread.
+        """
+        sock = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+        try:
+            sock.settimeout(self._connect_timeout)
+            sock.connect(self._socket_path)
+        except OSError as exc:
+            sock.close()
+            raise ConnectionError(
+                f"Failed to connect to Faramesh daemon at {self._socket_path}: {exc}"
+            ) from exc
+
+        # The daemon's callback_subscribe handler ignores agent_id, so we omit
+        # the field on that stream rather than sending an empty value.
+        payload: dict[str, Any] = {"type": self._request_type}
+        if self._request_type == AUDIT_SUBSCRIBE:
+            payload["agent_id"] = self._agent_id or ""
+        request = json.dumps(payload).encode("utf-8") + b"\n"
+        try:
+            sock.sendall(request)
+        except OSError as exc:
+            sock.close()
+            raise ConnectionError(
+                f"Failed to send {self._request_type} request: {exc}"
+            ) from exc
+
+        sock.settimeout(None)  # blocking mode for the long-lived stream
+        self._sock = sock
+        self._thread = threading.Thread(
+            target=self._run,
+            name=f"faramesh-{self._request_type.replace('_', '-')}",
+            daemon=True,
+        )
+        self._thread.start()
+
+        # Wait for the subscription confirmation (or an error from _run)
+        if not self._ready.wait(timeout=self._connect_timeout):
+            self.close()
+            raise TimeoutError(
+                "Did not receive subscription confirmation from Faramesh daemon"
+            )
+        if self._start_error is not None:
+            err = self._start_error
+            self.close()
+            raise err
+
+    def close(self) -> None:
+        """Stop the read loop and close the socket. Safe to call multiple times."""
+        self._stop.set()
+        if self._sock is not None:
+            try:
+                self._sock.shutdown(_socket.SHUT_RDWR)
+            except OSError:
+                pass
+            try:
+                self._sock.close()
+            except OSError:
+                pass
+            self._sock = None
+        if self._thread is not None and self._thread.is_alive():
+            self._thread.join(timeout=2.0)
+        self._thread = None
+
+    def _run(self) -> None:
+        """Background thread: read newline-delimited JSON events, invoke callback."""
+        assert self._sock is not None
+        sock = self._sock
+        buf = b""
+        confirmed = False
+
+        try:
+            while not self._stop.is_set():
+                try:
+                    chunk = sock.recv(4096)
+                except OSError:
+                    break
+                if not chunk:
+                    break
+                buf += chunk
+
+                while b"\n" in buf:
+                    line, buf = buf.split(b"\n", 1)
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        event = json.loads(line)
+                    except json.JSONDecodeError as exc:
+                        logger.warning("Skipping malformed event: %s", exc)
+                        continue
+
+                    if not confirmed:
+                        confirmed = True
+                        if event.get("subscribed") is True:
+                            self._ready.set()
+                            continue
+                        self._start_error = RuntimeError(
+                            f"Unexpected handshake response: {event}"
+                        )
+                        self._ready.set()
+                        return
+
+                    # Client-side agent_id filter (daemon does not filter)
+                    if self._agent_id and event.get("agent_id") != self._agent_id:
+                        continue
+
+                    try:
+                        self._callback(event)
+                    except Exception:
+                        logger.exception(
+                            "Subscription callback raised; stream continuing"
+                        )
+        finally:
+            # Unblock start() if we exited before confirmation
+            if not self._ready.is_set():
+                if self._start_error is None:
+                    self._start_error = ConnectionError(
+                        "Subscription stream ended before confirmation"
+                    )
+                self._ready.set()

--- a/sdk/python/faramesh/audit.py
+++ b/sdk/python/faramesh/audit.py
@@ -1,0 +1,78 @@
+"""Decision-stream subscription for the Faramesh daemon.
+
+Wraps the daemon's ``audit_subscribe`` socket protocol so Python
+consumers can react to every governance decision in real time. Same
+protocol as ``faramesh audit tail``.
+
+Each event is a governance **decision** (PERMIT / DENY / DEFER) at the
+moment it is made. To capture lifecycle events that follow a
+decision — the eventual approval or denial of a DEFER, expirations,
+and similar — also subscribe via :mod:`faramesh.callbacks`.
+
+Example:
+
+    >>> from faramesh import audit
+    >>>
+    >>> with audit.subscribe(lambda e: print(e["effect"], e["tool_id"])):
+    ...     run_my_agent()
+
+The callback runs on a background daemon thread. The daemon buffers ~64
+events per subscriber and silently drops further events if the consumer
+falls behind, so keep the callback fast — for slow downstream work
+(network calls, etc.), enqueue events and process them out-of-band.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from ._subscription import AUDIT_SUBSCRIBE, Subscription
+
+__all__ = ["Subscription", "subscribe"]
+
+
+def subscribe(
+    callback: Callable[[dict[str, Any]], None],
+    *,
+    agent_id: str | None = None,
+    socket_path: str | None = None,
+    connect_timeout: float = 5.0,
+) -> Subscription:
+    """Subscribe to the daemon's decision stream (``audit_subscribe``).
+
+    Each event is a dict with fields including ``effect``, ``agent_id``,
+    ``tool_id``, ``operation``, ``rule_id``, ``reason_code``, ``record_id``
+    (DPR record id), ``defer_token``, ``latency_ms``, ``timestamp``,
+    ``policy_version``, ``incident_category``, ``incident_severity``,
+    ``args``, and others.
+
+    Args:
+        callback: Invoked once per decision event from a background thread.
+        agent_id: Optional client-side filter. The daemon does not filter
+            by agent_id; the wrapper drops events whose ``agent_id`` field
+            does not match.
+        socket_path: Path to the daemon's Unix socket. Defaults to
+            ``$FARAMESH_SOCKET`` then ``/tmp/faramesh.sock``.
+        connect_timeout: Seconds to wait for connect and the
+            subscription confirmation.
+
+    Returns:
+        A ``Subscription`` handle. Use as a context manager or call
+        ``.close()`` to stop.
+
+    Raises:
+        ConnectionError: The socket could not be opened or the request
+            could not be sent.
+        TimeoutError: The daemon did not return the subscription
+            confirmation within ``connect_timeout`` seconds.
+    """
+    sub = Subscription(
+        callback,
+        request_type=AUDIT_SUBSCRIBE,
+        agent_id=agent_id,
+        socket_path=socket_path,
+        connect_timeout=connect_timeout,
+    )
+    sub.start()
+    return sub

--- a/sdk/python/faramesh/callbacks.py
+++ b/sdk/python/faramesh/callbacks.py
@@ -1,0 +1,91 @@
+"""Lifecycle-callback subscription for the Faramesh daemon.
+
+Wraps the daemon's ``callback_subscribe`` socket protocol so Python
+consumers can react to events that follow a governance decision —
+``defer_resolved`` (a deferred decision was approved or denied through
+the SDK or CLI), ``defer_expired``, and similar post-decision callbacks.
+
+Where :mod:`faramesh.audit` emits decisions at the moment they are
+made, this stream emits what happens to them afterwards.
+
+Each event includes ``event_type`` plus a payload appropriate to the
+event. For ``defer_resolved`` that is at minimum ``defer_token``,
+``status`` (``"approved"`` / ``"denied"`` / ``"expired"``), ``approved``
+(bool), ``approver_id``, ``reason``, and ``timestamp``. ``defer_token``
+links each resolution back to its originating DEFER record on the
+decision stream.
+
+Note: the daemon also mirrors every decision onto this stream as
+``event_type == "decision"`` (in addition to broadcasting on
+``audit_subscribe``). Consumers subscribing to both streams should
+filter that mirror out to avoid double-handling.
+
+Example:
+
+    >>> from faramesh import callbacks
+    >>>
+    >>> def on_event(event: dict) -> None:
+    ...     if event.get("event_type") == "defer_resolved":
+    ...         print(event["defer_token"], event["status"])
+    >>>
+    >>> with callbacks.subscribe(on_event):
+    ...     run_my_agent()
+
+The callback runs on a background daemon thread. The daemon buffers ~64
+events per subscriber and silently drops further events if the consumer
+falls behind.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from ._subscription import CALLBACK_SUBSCRIBE, Subscription
+
+__all__ = ["Subscription", "subscribe"]
+
+
+def subscribe(
+    callback: Callable[[dict[str, Any]], None],
+    *,
+    socket_path: str | None = None,
+    connect_timeout: float = 5.0,
+) -> Subscription:
+    """Subscribe to the daemon's lifecycle stream (``callback_subscribe``).
+
+    Emits events that follow a governance decision: ``defer_resolved``
+    (a deferred decision was approved or denied), ``defer_expired``, and
+    similar. Also mirrors every decision as ``event_type == "decision"``;
+    consumers subscribing to both streams should filter that mirror out.
+
+    Note: this stream does not support agent_id filtering. The daemon
+    doesn't filter, and many lifecycle events (notably ``defer_resolved``
+    from the ``agent approve`` CLI path) are sparse and don't include
+    ``agent_id``, so any client-side filter would silently drop them.
+    Filter inside your callback if needed.
+
+    Args:
+        callback: Invoked once per lifecycle event from a background thread.
+        socket_path: Path to the daemon's Unix socket. Defaults to
+            ``$FARAMESH_SOCKET`` then ``/tmp/faramesh.sock``.
+        connect_timeout: Seconds to wait for connect and the
+            subscription confirmation.
+
+    Returns:
+        A ``Subscription`` handle.
+
+    Raises:
+        ConnectionError: The socket could not be opened or the request
+            could not be sent.
+        TimeoutError: The daemon did not return the subscription
+            confirmation within ``connect_timeout`` seconds.
+    """
+    sub = Subscription(
+        callback,
+        request_type=CALLBACK_SUBSCRIBE,
+        socket_path=socket_path,
+        connect_timeout=connect_timeout,
+    )
+    sub.start()
+    return sub

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -1,0 +1,112 @@
+"""Shared fixtures and helpers for socket-stream subscription tests.
+
+A real Faramesh daemon isn't available in unit tests, so we stand up a
+mock Unix-socket server in a thread that mimics the daemon's
+subscribe-style protocols: read one newline-delimited JSON request,
+write a confirmation, then write canned events.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import tempfile
+import threading
+import time
+
+import pytest
+
+
+def _mock_subscribe_server(
+    socket_path: str,
+    events: list[dict],
+    started: threading.Event,
+    captured_request: list[dict],
+    confirmation: bytes,
+):
+    """Run a one-connection mock subscribe server on socket_path.
+
+    Captures the client's subscribe request into ``captured_request`` so
+    tests can assert on the wire format.
+    """
+    srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    srv.bind(socket_path)
+    srv.listen(1)
+    started.set()
+    try:
+        srv.settimeout(5.0)
+        conn, _ = srv.accept()
+    except socket.timeout:
+        srv.close()
+        return
+    try:
+        # Read the subscribe request (one newline-terminated JSON)
+        buf = b""
+        while b"\n" not in buf:
+            chunk = conn.recv(4096)
+            if not chunk:
+                break
+            buf += chunk
+        line, _ = buf.split(b"\n", 1)
+        try:
+            captured_request.append(json.loads(line))
+        except json.JSONDecodeError:
+            captured_request.append({"_malformed": line.decode("utf-8", "replace")})
+        # Send subscription confirmation
+        conn.sendall(confirmation)
+        # Send canned events
+        for event in events:
+            conn.sendall(json.dumps(event).encode("utf-8") + b"\n")
+            time.sleep(0.01)  # small gap so the consumer's recv loop interleaves
+        # Hold the connection open briefly, then close
+        time.sleep(0.1)
+    finally:
+        try:
+            conn.close()
+        except OSError:
+            pass
+        srv.close()
+
+
+@pytest.fixture
+def socket_path():
+    """Per-test temp Unix socket path."""
+    tmpdir = tempfile.mkdtemp()
+    path = os.path.join(tmpdir, "faramesh.sock")
+    yield path
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+    try:
+        os.rmdir(tmpdir)
+    except OSError:
+        pass
+
+
+@pytest.fixture
+def start_mock_server():
+    """Factory that starts a mock subscribe server. Returns (thread, captured_request_list).
+
+    Usage:
+        thread, captured = start_mock_server(socket_path, events, confirmation=b'...')
+    """
+
+    def _factory(
+        socket_path: str,
+        events: list[dict],
+        confirmation: bytes = b'{"subscribed": true}\n',
+    ) -> tuple[threading.Thread, list[dict]]:
+        started = threading.Event()
+        captured_request: list[dict] = []
+        thread = threading.Thread(
+            target=_mock_subscribe_server,
+            args=(socket_path, events, started, captured_request, confirmation),
+            daemon=True,
+        )
+        thread.start()
+        started.wait(timeout=2.0)
+        return thread, captured_request
+
+    return _factory

--- a/sdk/python/tests/test_audit.py
+++ b/sdk/python/tests/test_audit.py
@@ -1,0 +1,122 @@
+"""Tests for ``faramesh.audit`` (decision stream subscription)."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from faramesh import audit
+
+
+def test_subscribe_sends_audit_subscribe_request(socket_path, start_mock_server):
+    """The wire request is ``{"type":"audit_subscribe","agent_id":""}``."""
+    events = [
+        {"effect": "PERMIT", "agent_id": "bot", "tool_id": "t1", "record_id": "r1"},
+    ]
+    server, captured = start_mock_server(socket_path, events)
+
+    received: list[dict] = []
+    sub = audit.subscribe(received.append, socket_path=socket_path)
+    deadline = time.time() + 2.0
+    while time.time() < deadline and not received:
+        time.sleep(0.02)
+    sub.close()
+    server.join(timeout=2.0)
+
+    assert captured == [{"type": "audit_subscribe", "agent_id": ""}]
+
+
+def test_subscribe_receives_events(socket_path, start_mock_server):
+    """Callback fires once per event with the parsed dict."""
+    events = [
+        {"effect": "PERMIT", "agent_id": "bot", "tool_id": "t1", "record_id": "r1"},
+        {"effect": "DENY", "agent_id": "bot", "tool_id": "t2", "record_id": "r2"},
+    ]
+    server, _captured = start_mock_server(socket_path, events)
+
+    received: list[dict] = []
+    sub = audit.subscribe(received.append, socket_path=socket_path)
+
+    deadline = time.time() + 2.0
+    while time.time() < deadline and len(received) < 2:
+        time.sleep(0.02)
+    sub.close()
+    server.join(timeout=2.0)
+
+    assert len(received) == 2
+    assert received[0]["effect"] == "PERMIT"
+    assert received[0]["record_id"] == "r1"
+    assert received[1]["effect"] == "DENY"
+    assert received[1]["record_id"] == "r2"
+
+
+def test_subscribe_filters_by_agent_id(socket_path, start_mock_server):
+    """When agent_id is provided, events for other agents are dropped."""
+    events = [
+        {"effect": "PERMIT", "agent_id": "bot-a", "tool_id": "t1"},
+        {"effect": "PERMIT", "agent_id": "bot-b", "tool_id": "t2"},
+        {"effect": "PERMIT", "agent_id": "bot-a", "tool_id": "t3"},
+    ]
+    server, captured = start_mock_server(socket_path, events)
+
+    received: list[dict] = []
+    sub = audit.subscribe(received.append, socket_path=socket_path, agent_id="bot-a")
+
+    deadline = time.time() + 2.0
+    while time.time() < deadline and len(received) < 2:
+        time.sleep(0.02)
+    sub.close()
+    server.join(timeout=2.0)
+
+    assert captured == [{"type": "audit_subscribe", "agent_id": "bot-a"}]
+    assert len(received) == 2
+    assert all(e["agent_id"] == "bot-a" for e in received)
+
+
+def test_subscribe_context_manager(socket_path, start_mock_server):
+    """``with`` form opens and closes cleanly."""
+    events = [{"effect": "PERMIT", "agent_id": "bot", "tool_id": "t1"}]
+    server, _captured = start_mock_server(socket_path, events)
+
+    received: list[dict] = []
+    with audit.subscribe(received.append, socket_path=socket_path) as sub:
+        assert isinstance(sub, audit.Subscription)
+        deadline = time.time() + 2.0
+        while time.time() < deadline and not received:
+            time.sleep(0.02)
+
+    server.join(timeout=2.0)
+    assert len(received) == 1
+
+
+def test_subscribe_raises_when_socket_missing():
+    """Connecting to a nonexistent socket fails fast."""
+    with pytest.raises(ConnectionError):
+        audit.subscribe(lambda _: None, socket_path="/nonexistent/faramesh.sock")
+
+
+def test_callback_exception_does_not_kill_subscription(socket_path, start_mock_server):
+    """A raising callback is logged but the stream keeps running."""
+    events = [
+        {"effect": "PERMIT", "agent_id": "bot", "tool_id": "t1"},
+        {"effect": "PERMIT", "agent_id": "bot", "tool_id": "t2"},
+    ]
+    server, _captured = start_mock_server(socket_path, events)
+
+    received: list[dict] = []
+
+    def callback(event: dict) -> None:
+        received.append(event)
+        if len(received) == 1:
+            raise RuntimeError("intentional test failure")
+
+    sub = audit.subscribe(callback, socket_path=socket_path)
+
+    deadline = time.time() + 2.0
+    while time.time() < deadline and len(received) < 2:
+        time.sleep(0.02)
+    sub.close()
+    server.join(timeout=2.0)
+
+    assert len(received) == 2  # second event still delivered

--- a/sdk/python/tests/test_callbacks.py
+++ b/sdk/python/tests/test_callbacks.py
@@ -1,0 +1,111 @@
+"""Tests for ``faramesh.callbacks`` (lifecycle stream subscription)."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from faramesh import callbacks
+
+
+def test_subscribe_sends_callback_subscribe_request(socket_path, start_mock_server):
+    """The wire request is ``{"type":"callback_subscribe"}`` (no agent_id field).
+
+    The daemon's callback_subscribe handler ignores agent_id, so the
+    wrapper omits the field entirely from the request.
+    """
+    events = [
+        {
+            "event_type": "defer_resolved",
+            "defer_token": "abc123",
+            "status": "approved",
+            "approved": True,
+            "approver_id": "alice",
+            "reason": "looks good",
+        }
+    ]
+    server, captured = start_mock_server(
+        socket_path,
+        events,
+        confirmation=b'{"subscribed": true, "stream": "callbacks"}\n',
+    )
+
+    received: list[dict] = []
+    sub = callbacks.subscribe(received.append, socket_path=socket_path)
+
+    deadline = time.time() + 2.0
+    while time.time() < deadline and not received:
+        time.sleep(0.02)
+    sub.close()
+    server.join(timeout=2.0)
+
+    assert captured == [{"type": "callback_subscribe"}]
+    assert len(received) == 1
+    assert received[0]["event_type"] == "defer_resolved"
+    assert received[0]["defer_token"] == "abc123"
+    assert received[0]["status"] == "approved"
+
+
+def test_subscribe_receives_lifecycle_events(socket_path, start_mock_server):
+    """Multiple lifecycle events flow through the callback in order."""
+    events = [
+        {
+            "event_type": "defer_resolved",
+            "defer_token": "tok-1",
+            "status": "approved",
+            "approved": True,
+            "approver_id": "alice",
+        },
+        {
+            "event_type": "defer_resolved",
+            "defer_token": "tok-2",
+            "status": "denied",
+            "approved": False,
+            "approver_id": "bob",
+        },
+    ]
+    server, _captured = start_mock_server(
+        socket_path,
+        events,
+        confirmation=b'{"subscribed": true, "stream": "callbacks"}\n',
+    )
+
+    received: list[dict] = []
+    sub = callbacks.subscribe(received.append, socket_path=socket_path)
+
+    deadline = time.time() + 2.0
+    while time.time() < deadline and len(received) < 2:
+        time.sleep(0.02)
+    sub.close()
+    server.join(timeout=2.0)
+
+    assert len(received) == 2
+    assert received[0]["status"] == "approved"
+    assert received[1]["status"] == "denied"
+
+
+def test_subscribe_context_manager(socket_path, start_mock_server):
+    """``with`` form opens and closes cleanly."""
+    events = [{"event_type": "defer_resolved", "defer_token": "t", "status": "approved"}]
+    server, _captured = start_mock_server(
+        socket_path,
+        events,
+        confirmation=b'{"subscribed": true, "stream": "callbacks"}\n',
+    )
+
+    received: list[dict] = []
+    with callbacks.subscribe(received.append, socket_path=socket_path) as sub:
+        assert isinstance(sub, callbacks.Subscription)
+        deadline = time.time() + 2.0
+        while time.time() < deadline and not received:
+            time.sleep(0.02)
+
+    server.join(timeout=2.0)
+    assert len(received) == 1
+
+
+def test_subscribe_raises_when_socket_missing():
+    """Connecting to a nonexistent socket fails fast."""
+    with pytest.raises(ConnectionError):
+        callbacks.subscribe(lambda _: None, socket_path="/nonexistent/faramesh.sock")


### PR DESCRIPTION
## Summary

- **What:** Two new Python modules — `faramesh.audit` and `faramesh.callbacks` — wrapping the daemon's `audit_subscribe` and `callback_subscribe` socket protocols. Each exposes a `subscribe(callback)` factory and a shared `Subscription` handle (background read loop, context manager, clean shutdown).
- **Why:** Today these streams are only consumable from the Go CLI (`faramesh audit tail`). Python consumers — compliance loggers, observability sinks, dashboards — need an idiomatic entry point.

## Testing

- [x] `go test -race ./...` (no Go changes)
- [x] `go vet ./...` (no Go changes)
- [x] 10 new Python unit tests via mock Unix-socket server, all green:
  ```
  pytest sdk/python/tests/test_audit.py sdk/python/tests/test_callbacks.py
  ```

## Checklist

- [ ] Changelog updated if user-facing
- [ ] Docs updated or not needed (module docstrings cover the API and wire protocol)
- [ ] CI green